### PR TITLE
update non-working example in more-data section

### DIFF
--- a/content/moredata/2.md
+++ b/content/moredata/2.md
@@ -30,7 +30,12 @@ director.film (first: 1) {
     name
     initial_release_date
     genre { name }
-    starring { Performance }
+    starring { 
+        expand(Performance) {
+            uid
+            expand(_all_)
+        }
+    }
  }
 ```
 


### PR DESCRIPTION
Going through the tour, I got stuck for at least 2-3 hours trying to get this query (expanding and seeing all of the `starring` in a movie) to work.  Ended up dropping data, reimporting, and trying many schema tweaks many times.

I think either updating this section, or pre-filling the full, correct query would be very helpful and allow an easier transition for new users and learners.

Two versions of the full query are below:
```
{
  kathryn(func: eq(name@., "Kathryn Bigelow")) {
    uid
    name@.
    director.film (first: 1) {
      name@.
      initial_release_date
      genre { name@. }
      starring { 
        uid
        performance.film { name@. }
        performance.actor {
          name@.
        }
        performance.character {
          name@.
        }
      }
    }
  }
}
```

```
{
  kathryn(func: eq(name@., "Kathryn Bigelow")) {
    uid
    name@.
    director.film (first: 1) {
      name@.
      initial_release_date
      genre { name@. }
      starring { 
        expand(Performance) {
            uid
            expand(_all_)
        }
      }
    }
  }
}
```